### PR TITLE
Add Extractors

### DIFF
--- a/src/utils/extractors.js
+++ b/src/utils/extractors.js
@@ -1,0 +1,74 @@
+/**
+ * Returns the row where the specified cell is located.
+ *
+ * @param {number} rowIdx zero-based row index of the cell
+ * @param {number} colIdx zero-based column index of the cell
+ * @param {Array.<Array.<number>>} sudoku row representation of the sudoku
+ * @returns {Array.<number>} row containing the specified cell
+ */
+function getRowFromIndex(rowIdx, colIdx, sudoku) {
+  return sudoku[rowIdx].slice();
+}
+
+/**
+ * Returns the column where the specified cell is located.
+ *
+ * @param {number} rowIdx zero-based row index of the cell
+ * @param {number} colIdx zero-based column index of the cell
+ * @param {Array.<Array.<number>>} sudoku row representation of the sudoku
+ * @returns {Array.<number>} column containing the specified cell
+ */
+function getColumnFromIndex(rowIdx, colIdx, sudoku) {
+  const column = [];
+  sudoku.forEach((row) => column.push(row[colIdx]));
+  return column;
+}
+
+/**
+ * Computes the lower and upper bounds of the block where the index is located.
+ *
+ * @example
+ * // returns [0, 2]
+ * getBlockBoundsByIndex(0)
+ * @example
+ * // returns [3, 5]
+ * getBlockBoundsByIndex(5)
+ * @param {number} idx zero-based index of the cell (applies to rows and columns)
+ * @returns {Array.<number>} lower and upper block bounds of the given index
+ */
+function getBlockBoundsByIndex(idx) {
+  const idxRem = idx % 3;
+  return [
+    idxRem === 0 ? idx : idx - (idxRem),
+    idxRem === 2 ? idx : idx + 2 - (idxRem),
+  ];
+}
+
+/**
+ * Returns the block where the specified cell is located.
+ *
+ * @param {number} rowIdx zero-based row index of the cell
+ * @param {number} colIdx zero-based column index of the cell
+ * @param {Array.<Array.<number>>} sudoku row representation of the sudoku
+ * @returns {Array.<number>} block containing the specified cell
+ */
+function getBlockFromIndex(rowIdx, colIdx, sudoku) {
+  const [rowLow, rowHigh] = getBlockBoundsByIndex(rowIdx);
+  const [colLow, colHigh] = getBlockBoundsByIndex(colIdx);
+  const block = [];
+
+  for (let i = rowLow; i <= rowHigh; i += 1) {
+    for (let j = colLow; j <= colHigh; j += 1) {
+      block.push(sudoku[i][j]);
+    }
+  }
+
+  return block;
+}
+
+
+export {
+  getRowFromIndex,
+  getColumnFromIndex,
+  getBlockFromIndex,
+};

--- a/src/utils/tests/extractors.test.js
+++ b/src/utils/tests/extractors.test.js
@@ -1,0 +1,33 @@
+import _ from 'lodash';
+
+import { getRowFromIndex, getColumnFromIndex, getBlockFromIndex } from '../extractors';
+import sudoku from './mocks';
+
+describe('getRowFromIndex', () => {
+  test('returns the corresponding row', () => {
+    const idx = _.random(0, 8);
+    const row = sudoku.rows[idx];
+    expect(getRowFromIndex(idx, 0, sudoku.rows)).toStrictEqual(row);
+    expect(getRowFromIndex(idx, 0, sudoku.rows)).not.toBe(row);
+  });
+});
+
+describe('getColumnFromIndex', () => {
+  test('returns the corresponding column', () => {
+    const idx = _.random(0, 8);
+    const column = sudoku.columns[idx];
+    expect(getColumnFromIndex(0, idx, sudoku.rows)).toStrictEqual(column);
+    expect(getColumnFromIndex(0, idx, sudoku.rows)).not.toBe(column);
+  });
+});
+
+describe('getBlockFromIndex', () => {
+  test('returns the corresponding block', () => {
+    const rowIdx = _.random(0, 8);
+    const colIdx = _.random(0, 8);
+    const blockIdx = rowIdx - (rowIdx % 3) + Math.floor(colIdx / 3);
+    const block = sudoku.blocks[blockIdx];
+    expect(getBlockFromIndex(rowIdx, colIdx, sudoku.rows)).toStrictEqual(block);
+    expect(getBlockFromIndex(rowIdx, colIdx, sudoku.rows)).not.toBe(block);
+  });
+});

--- a/src/utils/tests/mocks.js
+++ b/src/utils/tests/mocks.js
@@ -1,0 +1,20 @@
+import { rowsToColumns, rowsToBlocks } from '../adaptors';
+
+const sudoku = {
+  rows: [
+    [1, 0, 0, 7, 0, 9, 0, 0, 0],
+    [5, 8, 0, 0, 0, 0, 0, 3, 0],
+    [7, 0, 6, 0, 0, 0, 0, 1, 9],
+    [0, 7, 0, 0, 0, 3, 0, 0, 8],
+    [9, 0, 1, 0, 0, 0, 0, 0, 2],
+    [6, 0, 8, 5, 0, 0, 0, 0, 7],
+    [0, 0, 7, 0, 3, 0, 0, 0, 0],
+    [0, 0, 0, 9, 0, 0, 4, 0, 3],
+    [0, 0, 4, 0, 7, 6, 8, 5, 0],
+  ],
+};
+
+sudoku.columns = rowsToColumns(sudoku.rows);
+sudoku.blocks = rowsToBlocks(sudoku.rows);
+
+export default sudoku;


### PR DESCRIPTION
Extractors are a way to extract certain parts of a given Sudoku without restructuring/recomputing the whole Sudoku. This is useful when:
- A new number is added to the Sudoku and we want to check if the number is valid
  - Valid is defined as no duplicates in the given row, column, and block
- Future feature implementations when want to hint the user